### PR TITLE
[TEST, DO NOT MERGE] Upgrade factory_girl_rails due to indentation bug.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :test, :development do
   gem 'thin'
   gem "rspec-rails", '~> 3.4.0'
   gem 'rspec-activemodel-mocks' # TODO: remove if we no longer need mock_model or stub_model
-  gem "factory_girl_rails", "~> 4.0"
+  gem "factory_girl_rails", "~> 4.6"
   gem "capybara"
   gem "guard-rspec", require: false
   gem 'guard-livereload'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,10 +116,10 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.7)
     execjs (2.5.2)
-    factory_girl (4.5.0)
+    factory_girl (4.7.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.5.0)
-      factory_girl (~> 4.5.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
       railties (>= 3.0.0)
     ffi (1.9.8)
     formatador (0.2.5)
@@ -354,7 +354,7 @@ DEPENDENCIES
   coffee-rails (~> 3.2.1)
   database_cleaner (= 1.0.1)
   devise (~> 2.2.1)
-  factory_girl_rails (~> 4.0)
+  factory_girl_rails (~> 4.6)
   geocoder
   guard-livereload
   guard-rspec


### PR DESCRIPTION
Factories generated during 'rails scaffold' are getting indented
strangely by the generator.  Hopefully this fixes it.  (See
https://github.com/thoughtbot/factory_girl_rails/issues/183.)
